### PR TITLE
add missing env var for dvc endpoint url

### DIFF
--- a/dags/regression_data_ingestion/README.md
+++ b/dags/regression_data_ingestion/README.md
@@ -6,23 +6,24 @@
     `pip install apache-airflow-providers-cncf-kubernetes`
 2. Set the following [Airflow variables](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html). Refer to the [Notes](#notes) for details.
 
-| Variable                   | Default Value                                                          | Description                                                                |
-|----------------------------|------------------------------------------------------------------------|----------------------------------------------------------------------------|
-| data_url                   | None                                                                   | Data url of the csv file. You should be able to access the file via `curl` |
-| namespace                  | `airflow`                                                              | Kubernetes cluster namespace                                               |
-| base_image_data_ingestion  | `ghcr.io/digicatapult/bridgeAI-regression-model-data-ingestion:latest` | Name of the data ingestion image                                           |
-| docker_reg_secret          | `ghcr-io`                                                              | Name of the secret for the docker registry pull                            |
-| data_ingestion_configmap   | `data-ingest-configmap`                                                | Name of the configmap containing the data ingestion config                 |
-| connection_id              | `local-k8s`                                                            | Kubernetes connection id                                                   |
-| in_cluster                 | `True`                                                                 | Run kubernetes client with in_cluster configuration                        |
-| github_secret              | `github-auth`                                                          | Name of the secret for git access                                          |
-| github_secret_username_key | `username`                                                             | Key corresponding to the git username in the above github_secret           |
-| github_secret_password_key | `password`                                                             | Key corresponding to the git password in the above github_secret           |
-| data_ingestion_pvc         | `data-ingestion-pvc`                                                   | The name of the PVC assigned for data ingestion DAG                        |
-| dvc_remote                 | "s3://artifacts"                                                       | dvc remote                                                                 |
-| dvc_remote_name            | "regression-model-remote"                                              | name for dvc remote                                                        |
-| dvc_access_key_id          | `admin`                                                                | access key for dvc remote                                                  |
-| dvc_secret_access_key      | `password`                                                             | secret access key for dvc remote                                           |
+| Variable                   | Default Value                                                          | Description                                                                                                         |
+|----------------------------|------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| data_url                   | None                                                                   | Data url of the csv file. You should be able to access the file via `curl`                                          |
+| namespace                  | `airflow`                                                              | Kubernetes cluster namespace                                                                                        |
+| base_image_data_ingestion  | `ghcr.io/digicatapult/bridgeAI-regression-model-data-ingestion:latest` | Name of the data ingestion image                                                                                    |
+| docker_reg_secret          | `ghcr-io`                                                              | Name of the secret for the docker registry pull                                                                     |
+| data_ingestion_configmap   | `data-ingest-configmap`                                                | Name of the configmap containing the data ingestion config                                                          |
+| connection_id              | `local-k8s`                                                            | Kubernetes connection id                                                                                            |
+| in_cluster                 | `True`                                                                 | Run kubernetes client with in_cluster configuration                                                                 |
+| github_secret              | `github-auth`                                                          | Name of the secret for git access                                                                                   |
+| github_secret_username_key | `username`                                                             | Key corresponding to the git username in the above github_secret                                                    |
+| github_secret_password_key | `password`                                                             | Key corresponding to the git password in the above github_secret                                                    |
+| data_ingestion_pvc         | `data-ingestion-pvc`                                                   | The name of the PVC assigned for data ingestion DAG                                                                 |
+| dvc_remote                 | "s3://artifacts"                                                       | dvc remote                                                                                                          |
+| dvc_remote_name            | "regression-model-remote"                                              | name for dvc remote                                                                                                 |
+| dvc_access_key_id          | `admin`                                                                | access key for dvc remote                                                                                           |
+| dvc_secret_access_key      | `password`                                                             | secret access key for dvc remote                                                                                    |
+| dvc_endpoint_url           | `http://minio`                                                         | The URL endpoint for the DVC storage backend. This is typically the URL of an S3-compatible service, such as MinIO  |
 
 3. Add the absolute path to `./dags` directory of this repo to the Airflow dags path using one of the method\
     a. Using the `airflow.cfg` file - Update the `dags_folder`

--- a/dags/regression_data_ingestion/data_ingestion_dag.py
+++ b/dags/regression_data_ingestion/data_ingestion_dag.py
@@ -13,6 +13,7 @@ docker_reg_secret = Variable.get("docker_reg_secret")
 namespace = Variable.get("namespace")
 base_image = Variable.get("base_image_data_ingestion")
 dvc_remote = Variable.get("dvc_remote")
+dvc_endpoint_url = Variable.get("dvc_endpoint_url")
 dvc_access_key_id = Variable.get("dvc_access_key_id")
 dvc_secret_access_key = Variable.get("dvc_secret_access_key")
 config_map = Variable.get("data_ingestion_configmap")
@@ -79,6 +80,7 @@ env_vars = [
     k8s.V1EnvVar(name="CONFIG_PATH", value="/config/config.yaml"),
     k8s.V1EnvVar(name="LOG_LEVEL", value=log_level),
     k8s.V1EnvVar(name="DVC_REMOTE", value=dvc_remote),
+    k8s.V1EnvVar(name="DVC_ENDPOINT_URL", value=dvc_endpoint_url),
     k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
     k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key),
     k8s.V1EnvVar(


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [x] Documentation Update

## Linked tickets

https://digicatapult.atlassian.net/browse/BRID-112

## High level description

The corresponding code changes to accept dvc endpoint url as an airflow variable and use that as an env var for the pod running data ingestion.

## Detailed description

<!-- A detailed description of the feature and if possible describe how has been implemented. -->


## Describe alternatives you've considered

<!-- A clear and concise description of the alternative solutions you've considered. Be sure to explain why the existing customisability isn't suitable for this feature. -->

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
