### PR TITLE
Catch malformed header values

### DIFF
--- a/dags/drift_monitoring/drift_monitoring_dag.py
+++ b/dags/drift_monitoring/drift_monitoring_dag.py
@@ -26,8 +26,9 @@ dvc_remote_region = Variable.get("dvc_remote_region", default_var="eu-west-2")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
+print(conn)
 # Extract connection details
-if (conn.login and conn.password) is not None:
+if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID
     dvc_secret_access_key = conn.password  # Secret Access Key
 
@@ -93,8 +94,6 @@ env_vars = [
     k8s.V1EnvVar(name="LOG_LEVEL", value=log_level),
     k8s.V1EnvVar(name="DVC_REMOTE", value=dvc_remote),
     k8s.V1EnvVar(name="DVC_ENDPOINT_URL", value=dvc_endpoint_url),
-    k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
-    k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key),
     k8s.V1EnvVar(name="AWS_DEFAULT_REGION", value=dvc_remote_region),
     k8s.V1EnvVar(name="DATA_REPO", value=data_repo),
     k8s.V1EnvVar(
@@ -121,6 +120,12 @@ env_vars = [
     ),
     k8s.V1EnvVar(name="CONFIG_PATH", value="/config/config.yaml"),
 ]
+
+if (conn.login and conn.password) != "":
+    env_vars = [*env_vars, *[
+        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
+        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key)]
+    ]
 
 
 @dag(schedule=None, catchup=False)

--- a/dags/drift_monitoring/drift_monitoring_dag.py
+++ b/dags/drift_monitoring/drift_monitoring_dag.py
@@ -126,12 +126,6 @@ env_vars = [*env_vars, *[
     k8s.V1EnvVar(name="CONFIG_PATH", value="/config/config.yaml"),
 ]]
 
-if (conn.login and conn.password) != "":
-    env_vars = [*env_vars, *[
-        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
-        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key)]
-    ]
-
 
 @dag(schedule=None, catchup=False)
 def drift_monitoring_dag():

--- a/dags/drift_monitoring/drift_monitoring_dag.py
+++ b/dags/drift_monitoring/drift_monitoring_dag.py
@@ -26,10 +26,16 @@ dvc_remote_region = Variable.get("dvc_remote_region", default_var="eu-west-2")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
+env_vars = []
+
 # Extract connection details
 if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID
     dvc_secret_access_key = conn.password  # Secret Access Key
+    env_vars = [*env_vars, *[
+        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
+        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key),
+    ]]
 
 github_secret = Variable.get("github_secret", default_var="github-auth")
 github_secret_username_key = Variable.get(
@@ -88,7 +94,7 @@ config_volume_mount = k8s.V1VolumeMount(
     read_only=True,
 )
 
-env_vars = [
+env_vars = [*env_vars, *[
     k8s.V1EnvVar(name="CONFIG_PATH", value="/config/config.yaml"),
     k8s.V1EnvVar(name="LOG_LEVEL", value=log_level),
     k8s.V1EnvVar(name="DVC_REMOTE", value=dvc_remote),
@@ -118,7 +124,7 @@ env_vars = [
         ),
     ),
     k8s.V1EnvVar(name="CONFIG_PATH", value="/config/config.yaml"),
-]
+]]
 
 if (conn.login and conn.password) != "":
     env_vars = [*env_vars, *[

--- a/dags/drift_monitoring/drift_monitoring_dag.py
+++ b/dags/drift_monitoring/drift_monitoring_dag.py
@@ -26,7 +26,6 @@ dvc_remote_region = Variable.get("dvc_remote_region", default_var="eu-west-2")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
-print(conn)
 # Extract connection details
 if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID

--- a/dags/drift_monitoring/drift_monitoring_dag.py
+++ b/dags/drift_monitoring/drift_monitoring_dag.py
@@ -27,8 +27,9 @@ conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
 # Extract connection details
-dvc_access_key_id = conn.login  # Access Key ID
-dvc_secret_access_key = conn.password  # Secret Access Key
+if (conn.login and conn.password) is not None:
+    dvc_access_key_id = conn.login  # Access Key ID
+    dvc_secret_access_key = conn.password  # Secret Access Key
 
 github_secret = Variable.get("github_secret", default_var="github-auth")
 github_secret_username_key = Variable.get(

--- a/dags/regression_data_ingestion/data_ingestion_dag.py
+++ b/dags/regression_data_ingestion/data_ingestion_dag.py
@@ -25,8 +25,9 @@ conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
 # Extract connection details
-dvc_access_key_id = conn.login  # Access Key ID
-dvc_secret_access_key = conn.password  # Secret Access Key
+if (conn.login and conn.password) is not None:
+    dvc_access_key_id = conn.login  # Access Key ID
+    dvc_secret_access_key = conn.password  # Secret Access Key
 
 config_map = Variable.get("data_ingestion_configmap")
 connection_id = Variable.get("connection_id")

--- a/dags/regression_data_ingestion/data_ingestion_dag.py
+++ b/dags/regression_data_ingestion/data_ingestion_dag.py
@@ -24,8 +24,9 @@ deploy_as_code = Variable.get("deploy_as_code", default_var="False")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
+print(conn)
 # Extract connection details
-if (conn.login and conn.password) is not None:
+if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID
     dvc_secret_access_key = conn.password  # Secret Access Key
 
@@ -106,8 +107,6 @@ env_vars = [
     k8s.V1EnvVar(name="LOG_LEVEL", value=log_level),
     k8s.V1EnvVar(name="DVC_REMOTE", value=dvc_remote),
     k8s.V1EnvVar(name="DVC_ENDPOINT_URL", value=dvc_endpoint_url),
-    k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
-    k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key),
     k8s.V1EnvVar(name="AWS_DEFAULT_REGION", value=dvc_remote_region),
     k8s.V1EnvVar(
         name="GITHUB_USERNAME",
@@ -126,6 +125,12 @@ env_vars = [
         ),
     ),
 ]
+
+if (conn.login and conn.password) != "":
+    env_vars = [*env_vars, *[
+        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
+        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key)]
+    ]
 
 
 @dag(schedule=None, catchup=False)

--- a/dags/regression_data_ingestion/data_ingestion_dag.py
+++ b/dags/regression_data_ingestion/data_ingestion_dag.py
@@ -131,12 +131,6 @@ env_vars = [*env_vars, *[
     ),
 ]]
 
-if (conn.login and conn.password) != "":
-    env_vars = [*env_vars, *[
-        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
-        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key)]
-    ]
-
 
 @dag(schedule=None, catchup=False)
 def data_ingestion_dag():

--- a/dags/regression_data_ingestion/data_ingestion_dag.py
+++ b/dags/regression_data_ingestion/data_ingestion_dag.py
@@ -24,10 +24,16 @@ deploy_as_code = Variable.get("deploy_as_code", default_var="False")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
+env_vars = []
+
 # Extract connection details
 if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID
     dvc_secret_access_key = conn.password  # Secret Access Key
+    env_vars = [*env_vars, *[
+        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
+        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key),
+    ]]
 
 config_map = Variable.get("data_ingestion_configmap")
 connection_id = Variable.get("connection_id")
@@ -101,7 +107,7 @@ else:
     image_pull_secrets = None
 
 # Define the environment variables
-env_vars = [
+env_vars = [*env_vars, *[
     k8s.V1EnvVar(name="CONFIG_PATH", value="/config/config.yaml"),
     k8s.V1EnvVar(name="LOG_LEVEL", value=log_level),
     k8s.V1EnvVar(name="DVC_REMOTE", value=dvc_remote),
@@ -123,7 +129,7 @@ env_vars = [
             )
         ),
     ),
-]
+]]
 
 if (conn.login and conn.password) != "":
     env_vars = [*env_vars, *[

--- a/dags/regression_data_ingestion/data_ingestion_dag.py
+++ b/dags/regression_data_ingestion/data_ingestion_dag.py
@@ -24,7 +24,6 @@ deploy_as_code = Variable.get("deploy_as_code", default_var="False")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
-print(conn)
 # Extract connection details
 if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID

--- a/dags/regression_model_training/train_dag.py
+++ b/dags/regression_model_training/train_dag.py
@@ -24,10 +24,16 @@ dvc_remote = Variable.get("dvc_remote")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
+env_vars = []
+
 # Extract connection details
 if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID
     dvc_secret_access_key = conn.password  # Secret Access Key
+    env_vars = [*env_vars, *[
+        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
+        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key),
+    ]]
 
 dvc_endpoint_url = Variable.get("dvc_endpoint_url")
 dvc_remote_region = Variable.get("dvc_remote_region", default_var="eu-west-2")
@@ -98,7 +104,7 @@ config_volume_mount = k8s.V1VolumeMount(
     read_only=True,
 )
 
-env_vars = [
+env_vars = [*env_vars, *[
     k8s.V1EnvVar(name="CONFIG_PATH", value="/config/config.yaml"),
     k8s.V1EnvVar(name="LOG_LEVEL", value=log_level),
     k8s.V1EnvVar(name="DVC_REMOTE", value=dvc_remote),
@@ -132,13 +138,7 @@ env_vars = [
     k8s.V1EnvVar(name="DEPLOY_AS_CODE", value=deploy_as_code),
     k8s.V1EnvVar(name="DEPLOY_MODEL_NAME", value=deploy_model_name),
     k8s.V1EnvVar(name="DEPLOY_MODEL_ALIAS", value=deploy_model_alias),
-]
-
-if (conn.login and conn.password) != "":
-    env_vars = [*env_vars, *[
-        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
-        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key)]
-    ]
+]]
 
 
 def extract_run_id(**kwargs):

--- a/dags/regression_model_training/train_dag.py
+++ b/dags/regression_model_training/train_dag.py
@@ -24,8 +24,9 @@ dvc_remote = Variable.get("dvc_remote")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
+print(conn)
 # Extract connection details
-if (conn.login and conn.password) is not None:
+if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID
     dvc_secret_access_key = conn.password  # Secret Access Key
 
@@ -103,8 +104,6 @@ env_vars = [
     k8s.V1EnvVar(name="LOG_LEVEL", value=log_level),
     k8s.V1EnvVar(name="DVC_REMOTE", value=dvc_remote),
     k8s.V1EnvVar(name="DVC_ENDPOINT_URL", value=dvc_endpoint_url),
-    k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
-    k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key),
     k8s.V1EnvVar(name="AWS_DEFAULT_REGION", value=dvc_remote_region),
     k8s.V1EnvVar(name="DATA_VERSION", value=data_version),
     k8s.V1EnvVar(
@@ -135,6 +134,12 @@ env_vars = [
     k8s.V1EnvVar(name="DEPLOY_MODEL_NAME", value=deploy_model_name),
     k8s.V1EnvVar(name="DEPLOY_MODEL_ALIAS", value=deploy_model_alias),
 ]
+
+if (conn.login and conn.password) != "":
+    env_vars = [*env_vars, *[
+        k8s.V1EnvVar(name="DVC_ACCESS_KEY_ID", value=dvc_access_key_id),
+        k8s.V1EnvVar(name="DVC_SECRET_ACCESS_KEY", value=dvc_secret_access_key)]
+    ]
 
 
 def extract_run_id(**kwargs):

--- a/dags/regression_model_training/train_dag.py
+++ b/dags/regression_model_training/train_dag.py
@@ -24,7 +24,6 @@ dvc_remote = Variable.get("dvc_remote")
 conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
-print(conn)
 # Extract connection details
 if (conn.login and conn.password) != "":
     dvc_access_key_id = conn.login  # Access Key ID

--- a/dags/regression_model_training/train_dag.py
+++ b/dags/regression_model_training/train_dag.py
@@ -25,8 +25,9 @@ conn_id = Variable.get("aws_conn_name", default_var="aws_default")
 conn = BaseHook.get_connection(conn_id)
 
 # Extract connection details
-dvc_access_key_id = conn.login  # Access Key ID
-dvc_secret_access_key = conn.password  # Secret Access Key
+if (conn.login and conn.password) is not None:
+    dvc_access_key_id = conn.login  # Access Key ID
+    dvc_secret_access_key = conn.password  # Secret Access Key
 
 dvc_endpoint_url = Variable.get("dvc_endpoint_url")
 dvc_remote_region = Variable.get("dvc_remote_region", default_var="eu-west-2")


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Chore

## High level description

When pushing within AWS infrastructure, e.g. an EKS cluster, DVC expects non-empty credentials for making the ListObjectsV2 API call. We expect to be able to use OIDC, however, and a role already exists with the STS required. This PR is intended to introduce additional logic to begin catching problems, if any, with the connection struct returned by Airflow, which is then used later to create environment variables for `dvc push` within the container.

## Detailed description

For reference, the bug encountered is this:
```
ERROR: unexpected error - [Errno 22] The authorization header is malformed; a non-empty
Access Key (AKID) must be provided in the credential.: An error occurred
(AuthorizationHeaderMalformed) when calling the ListObjectsV2 operation: The authorization
header is malformed; a non-empty Access Key (AKID) must be provided in the credential.
```